### PR TITLE
Support path_prefix option similar to LocalFileInputPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The plugin searches line separators and splits a file properly.
 
 ## Configuration
 
-- **path**: the path of a text file (string, required)
+- **path**: the path of a text file (string, either this or path_prefix is required)
+- **path_prefix**: the path prefix of text files (string,  either this or path_prefix is required)
 - **header_line**: whether the first line is a header or not (boolean, default: false)
 - **tasks**: number of tasks (integer, default: number of available processors * 2)
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'com.github.jruby-gradle.base'
 
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
-project.version = '0.1.3'
+project.version = '0.1.4'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
I'd like to use `path_prefix`option instead of `path`,  similar to [Local file input plugin](http://www.embulk.org/docs/built-in.html#local-file-input-plugin).